### PR TITLE
Update recommended app name

### DIFF
--- a/karabiner/private.xml
+++ b/karabiner/private.xml
@@ -67,7 +67,7 @@
     -->
     <name>F19 to Escape/Control</name>
     <appendix>Tap F19 for Escape; Hold F19 for Control</appendix>
-    <appendix>(Recommendation: Use PCKeyboardHack to remap Caps Lock to F19.)</appendix>
+    <appendix>(Recommendation: Use Seil to remap Caps Lock to F19.)</appendix>
     <identifier>com.jasonrudolph.f192f19_escape_or_control</identifier>
     <autogen>
       --KeyOverlaidModifier--


### PR DESCRIPTION
PCKeyboardHack was renamed to Seil in v10.8.0

https://pqrs.org/osx/karabiner/seil.html.en#history
