### PR TITLE
super.lua: allow normal flag modifier keys

### DIFF
--- a/hammerspoon/super.lua
+++ b/hammerspoon/super.lua
@@ -126,11 +126,15 @@ superDuperModeNavListener = eventtap.new({ eventTypes.keyDown }, function(event)
     l = 'right',
   }
 
-  local keystroke = charactersToKeystrokes[event:getCharacters()]
+  local keystroke = charactersToKeystrokes[event:getCharacters(true)]
   if keystroke then
     local modifiers = {}
     n = 0
     for k, v in pairs(superDuperMode.modifiers) do
+      n = n + 1
+      modifiers[n] = k
+    end
+    for k, v in pairs(event:getFlags()) do
       n = n + 1
       modifiers[n] = k
     end


### PR DESCRIPTION
By stripping the flags from the keystroke character and then adding them back as modifiers, you can enable the normal cmd, ctrl, etc keys to work when super duper mode is enabled (in addition to the custom a, f, etc).