### PR TITLE
Add markdown mode c for wrapping with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Use **control** + **m** to turn on Markdown Mode. Then, use any shortcut below t
 
     Example: `**selection**`
 
+- Use **c** to wrap the currently-selected text in backticks ("C" for "Code")
+
+    Example: `` `selection` ``
+
 - Use **i** to wrap the currently-selected text in single asterisks ("I" for "Italic")
 
     Example: `*selection*`

--- a/hammerspoon/markdown.lua
+++ b/hammerspoon/markdown.lua
@@ -98,6 +98,10 @@ markdownMode:bindWithAutomaticExit('l', function()
   inlineLink()
 end)
 
+markdownMode:bindWithAutomaticExit('c', function()
+  wrapSelectedText('`')
+end)
+
 -- Use Control+m to toggle Markdown Mode
 hs.hotkey.bind({'ctrl'}, 'm', function()
   markdownMode:enter()

--- a/hammerspoon/markdown.lua
+++ b/hammerspoon/markdown.lua
@@ -57,6 +57,7 @@ end
 -- selected text in double asterisks, hit Control+m, and then b.
 --
 --   b => wrap the selected text in double asterisks ("b" for "bold")
+--   c => wrap the selected text in backticks ("c" for "code")
 --   i => wrap the selected text in single asterisks ("i" for "italic")
 --   s => wrap the selected text in double tildes ("s" for "strikethrough")
 --   l => convert the currently-selected text to an inline link, using a URL


### PR DESCRIPTION
I do a decent amount of code styling in markdown and found myself wanting a code wrapping combo in markdown mode. This adds `markdown mode + c` to wrap selection with backticks. I thought about using markdown mode + \`, but I felt `c` was closer to home row and couldn't think of another thing I would map `c` to for markdown mode.