### PR TITLE
Symlink karabiner dir instead of just config file

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -7,8 +7,8 @@ which -s brew || (echo "Homebrew is required: http://brew.sh/" && exit 1)
 brew bundle check || brew bundle
 
 # Prepare custom settings for Karabiner-Elements
-mkdir -p ~/.config/karabiner/
-ln -sf $PWD/karabiner/karabiner.json ~/.config/karabiner/karabiner.json
+# https://github.com/tekezo/Karabiner-Elements/issues/597#issuecomment-282760186
+ln -sfn $PWD/karabiner ~/.config/
 
 # Prepare custom settings for Hammerspoon
 ln -sfn $PWD/hammerspoon ~/.hammerspoon


### PR DESCRIPTION
Due to limitation in mac osx, the file alone isn't enough to trigger changes when the file updates. This meant that I needed to restart karabiner-elements after switching profiles or any changes to a profile. Moving to the dir fixed the issue.

xref https://github.com/tekezo/Karabiner-Elements/issues/597#issuecomment-282760186