### PR TITLE
Add left/right bindings to move windows across screens

### DIFF
--- a/hammerspoon/windows.lua
+++ b/hammerspoon/windows.lua
@@ -248,6 +248,14 @@ windowLayoutMode:bindWithAutomaticExit('n', function()
   hs.window.focusedWindow():nextScreen()
 end)
 
+windowLayoutMode:bindWithAutomaticExit('right', function()
+  hs.window.focusedWindow():moveOneScreenEast()
+end)
+
+windowLayoutMode:bindWithAutomaticExit('left', function()
+  hs.window.focusedWindow():moveOneScreenWest()
+end)
+
 -- Use Control+s to toggle WindowLayout Mode
 hs.hotkey.bind({'ctrl'}, 's', function()
   windowLayoutMode:enter()


### PR DESCRIPTION
Add left/right bindings to move windows across screens,

This is mainly useful if there's more than 2 monitors connected.