### PR TITLE
More reliably exit Hyper Mode when hyper key is released 🤞

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Edit [`hammerspoon/hyper.lua`](hammerspoon/hyper.lua) to configure shortcuts to 
 This setup is honed and tested with the following dependencies.
 
 - macOS Sierra, 10.12
-- [Karabiner-Elements 0.90.92][karabiner]
+- [Karabiner-Elements 0.91.7][karabiner]
 - [Hammerspoon 0.9.52][hammerspoon]
 
 ## Installation

--- a/hammerspoon/hyper.lua
+++ b/hammerspoon/hyper.lua
@@ -1,8 +1,16 @@
+-- A global variable for Hyper Mode
+hyperMode = hs.hotkey.modal.new({}, 'F18')
+
 local message = require('keyboard.status-message')
 statusMessage = message.new('Hyper Mode')
 
--- A global variable for Hyper Mode
-hyperMode = hs.hotkey.modal.new({}, 'F18')
+function hyperMode:entered()
+  statusMessage:show()
+end
+
+function hyperMode:exited()
+  statusMessage:hide()
+end
 
 -- Keybindings for launching apps in Hyper Mode
 hyperModeAppMappings = {
@@ -26,13 +34,24 @@ end
 -- Enter Hyper Mode when F17 (right option key) is pressed
 pressedF17 = function()
   hyperMode:enter()
-  statusMessage:show()
+
+  -- The releasedF17 function *should* get called when the Hyper key is
+  -- released, but for some reason it seems that Hammerspoon sometimes fails to
+  -- invoke that function. If Hammerspoon fails to invoke the releasedF17
+  -- function, we end up stuck in Hyper Mode until the user once again presses
+  -- and releases the Hyper Key. 🙀
+  --
+  -- To reduce the likelihood of getting stuck in Hyper Mode, set a timer to
+  -- automatically exit Hyper Mode after a short while.
+  local TIMEOUT_IN_SECONDS = 5
+  hs.timer.doAfter(TIMEOUT_IN_SECONDS, function()
+    hyperMode:exit()
+  end)
 end
 
 -- Leave Hyper Mode when F17 (right option key) is released.
 releasedF17 = function()
   hyperMode:exit()
-  statusMessage:hide()
 end
 
 -- Bind the Hyper key

--- a/hammerspoon/hyper.lua
+++ b/hammerspoon/hyper.lua
@@ -23,12 +23,16 @@ end
 -- Enter Hyper Mode when F17 (right option key) is pressed
 pressedF17 = function()
   hyperMode:enter()
+  hyperModeDeactivationListener:start()
 end
 
 -- Leave Hyper Mode when F17 (right option key) is released.
-releasedF17 = function()
-  hyperMode:exit()
-end
+hyperModeDeactivationListener = hs.eventtap.new({ hs.eventtap.event.types.keyUp }, function(event)
+  if event:getKeyCode() == hs.keycodes.map['F17'] then
+    hyperMode:exit()
+    hyperModeDeactivationListener:stop()
+  end
+end)
 
 -- Bind the Hyper key
-f17 = hs.hotkey.bind({}, 'F17', pressedF17, releasedF17)
+f17 = hs.hotkey.bind({}, 'F17', pressedF17)

--- a/hammerspoon/hyper.lua
+++ b/hammerspoon/hyper.lua
@@ -1,3 +1,6 @@
+local message = require('keyboard.status-message')
+statusMessage = message.new('Hyper Mode')
+
 -- A global variable for Hyper Mode
 hyperMode = hs.hotkey.modal.new({}, 'F18')
 
@@ -24,6 +27,7 @@ end
 pressedF17 = function()
   hyperMode:enter()
   hyperModeDeactivationListener:start()
+  statusMessage:show()
 end
 
 -- Leave Hyper Mode when F17 (right option key) is released.
@@ -31,6 +35,7 @@ hyperModeDeactivationListener = hs.eventtap.new({ hs.eventtap.event.types.keyUp 
   if event:getKeyCode() == hs.keycodes.map['F17'] then
     hyperMode:exit()
     hyperModeDeactivationListener:stop()
+    statusMessage:hide()
   end
 end)
 

--- a/hammerspoon/hyper.lua
+++ b/hammerspoon/hyper.lua
@@ -43,7 +43,7 @@ pressedF17 = function()
   --
   -- To reduce the likelihood of getting stuck in Hyper Mode, set a timer to
   -- automatically exit Hyper Mode after a short while.
-  local TIMEOUT_IN_SECONDS = 5
+  local TIMEOUT_IN_SECONDS = 10
   hs.timer.doAfter(TIMEOUT_IN_SECONDS, function()
     hyperMode:exit()
   end)

--- a/hammerspoon/hyper.lua
+++ b/hammerspoon/hyper.lua
@@ -1,17 +1,3 @@
--- A global variable for Hyper Mode
-hyperMode = hs.hotkey.modal.new({}, 'F18')
-
-local message = require('keyboard.status-message')
-statusMessage = message.new('Hyper Mode')
-
-function hyperMode:entered()
-  statusMessage:show()
-end
-
-function hyperMode:exited()
-  statusMessage:hide()
-end
-
 -- Keybindings for launching apps in Hyper Mode
 hyperModeAppMappings = {
   { 'a', 'iTunes' },                -- "A" for "Apple Music"
@@ -26,33 +12,7 @@ hyperModeAppMappings = {
 }
 
 for i, mapping in ipairs(hyperModeAppMappings) do
-  hyperMode:bind({}, mapping[1], function()
+  hs.hotkey.bind({'shift', 'ctrl', 'alt', 'cmd'}, mapping[1], function()
     hs.application.launchOrFocus(mapping[2])
   end)
 end
-
--- Enter Hyper Mode when F17 (right option key) is pressed
-pressedF17 = function()
-  hyperMode:enter()
-
-  -- The releasedF17 function *should* get called when the Hyper key is
-  -- released, but for some reason it seems that Hammerspoon sometimes fails to
-  -- invoke that function. If Hammerspoon fails to invoke the releasedF17
-  -- function, we end up stuck in Hyper Mode until the user once again presses
-  -- and releases the Hyper Key. 🙀
-  --
-  -- To reduce the likelihood of getting stuck in Hyper Mode, set a timer to
-  -- automatically exit Hyper Mode after a short while.
-  local TIMEOUT_IN_SECONDS = 10
-  hs.timer.doAfter(TIMEOUT_IN_SECONDS, function()
-    hyperMode:exit()
-  end)
-end
-
--- Leave Hyper Mode when F17 (right option key) is released.
-releasedF17 = function()
-  hyperMode:exit()
-end
-
--- Bind the Hyper key
-f17 = hs.hotkey.bind({}, 'F17', pressedF17, releasedF17)

--- a/hammerspoon/hyper.lua
+++ b/hammerspoon/hyper.lua
@@ -26,18 +26,14 @@ end
 -- Enter Hyper Mode when F17 (right option key) is pressed
 pressedF17 = function()
   hyperMode:enter()
-  hyperModeDeactivationListener:start()
   statusMessage:show()
 end
 
 -- Leave Hyper Mode when F17 (right option key) is released.
-hyperModeDeactivationListener = hs.eventtap.new({ hs.eventtap.event.types.keyUp }, function(event)
-  if event:getKeyCode() == hs.keycodes.map['F17'] then
-    hyperMode:exit()
-    hyperModeDeactivationListener:stop()
-    statusMessage:hide()
-  end
-end)
+releasedF17 = function()
+  hyperMode:exit()
+  statusMessage:hide()
+end
 
 -- Bind the Hyper key
-f17 = hs.hotkey.bind({}, 'F17', pressedF17)
+f17 = hs.hotkey.bind({}, 'F17', pressedF17, releasedF17)

--- a/karabiner/karabiner.json
+++ b/karabiner/karabiner.json
@@ -6,6 +6,39 @@
     },
     "profiles": [
         {
+            "complex_modifications": {
+                "parameters": {
+                    "basic.to_if_alone_timeout_milliseconds": 1000
+                },
+                "rules": [
+                    {
+                        "manipulators": [
+                            {
+                                "description": "Change right option to Hyper (i.e., command+control+option+shift)",
+                                "from": {
+                                    "key_code": "right_option",
+                                    "modifiers": {
+                                        "optional": [
+                                            "any"
+                                        ]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "left_shift",
+                                        "modifiers": [
+                                            "left_control",
+                                            "left_option",
+                                            "left_command"
+                                        ]
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
             "devices": [
                 {
                     "disable_built_in_keyboard_if_exists": false,
@@ -35,8 +68,7 @@
             "name": "Default profile",
             "selected": true,
             "simple_modifications": {
-                "caps_lock": "left_control",
-                "right_option": "f17"
+                "caps_lock": "left_control"
             },
             "virtual_hid_keyboard": {
                 "caps_lock_delay_milliseconds": 0,


### PR DESCRIPTION
For some reason, even after releasing the hyper key (i.e., [`F17`](https://github.com/jasonrudolph/keyboard/blob/2d99766be27d342a234a1cbca1649bb420bdd48e/hammerspoon/hyper.lua#L42), which happens to be [mapped to the right option key](https://github.com/jasonrudolph/keyboard/blob/0c4941b4ebc20d643fff3b7055b0d141b1522bf8/karabiner/karabiner.json#L39)), I notice that the we're still in [Hyper Mode](https://github.com/jasonrudolph/keyboard/tree/0c4941b4ebc20d643fff3b7055b0d141b1522bf8#hyper-key-for-quickly-launching-apps). As a result, when I'm attempting to type some text, I end up unintentionally opening/focusing apps instead of entering text. 😱

It _seems_ that sometimes Hammerspoon isn't calling the `releasedF17` function when `F17` is released. Instead of passing the `releasedfn` to `hs.hotkey.bind`, let's try using an eventtap to manually watch for an `F17` keyup event. _Maybe_ this will produce more reliable results?

Also, in case this change doesn't provide more reliable exiting of Hyper Mode, let's also display a status message any time you're in Hyper Mode. That way, at least if you accidentally start opening/focusing apps, you can more quickly detect that the issue is due to being in Hyper Mode.
