### PR TITLE
adds issues section to readme for common problems with installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ This setup is honed and tested with the following dependencies.
 
 2. Enable accessibility to allow Hammerspoon to do its thing [[screenshot]](screenshots/accessibility-permissions-for-hammerspoon.png)
 
+## Common Issues
+
+If you see the error `ln: your/home/path/.config//karabiner: Operation not permitted`,
+then you probably have an existing configuration folder for karabiner.
+You will need to move, remove, or change the name of the folder and run `script/setup`
+again.
+
 ## TODO
 
 - Add [#13](https://github.com/jasonrudolph/keyboard/pull/13) to [features](#features):


### PR DESCRIPTION
We attempting to setup keyboard I ran into an issue caused by an existing karabiner configuration folder in `~/.config`. I noticed this issue had been reported in the projects issues. I figured this could be added to the readme, rather than forcing the removal of someone's karabiner configurations. Hope this helps!