### PR TITLE
Windows bindings defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 hammerspoon/hyper-apps.lua
+hammerspoon/windows-bindings.lua

--- a/hammerspoon/windows-bindings-defaults.lua
+++ b/hammerspoon/windows-bindings-defaults.lua
@@ -26,6 +26,7 @@
 
 return {
   modifiers = {'ctrl'},
+  showHelp  = false,
   trigger   = 's',
   mappings  = {
     { {},         'return', 'maximize' },

--- a/hammerspoon/windows-bindings-defaults.lua
+++ b/hammerspoon/windows-bindings-defaults.lua
@@ -1,0 +1,47 @@
+-- Default keybindings for WindowLayout Mode
+--
+-- To customize the key bindings for WindowLayout Mode, create a copy of this
+-- file, save it as `windows-bindings.lua`, and edit the table below to
+-- configure your preferred shortcuts.
+
+--------------------------------------------------------------------------------
+-- Define WindowLayout Mode
+--
+-- WindowLayout Mode allows you to manage window layout using keyboard shortcuts
+-- that are on the home row, or very close to it. Use Control+s to turn
+-- on WindowLayout mode. Then, use any shortcut below to perform a window layout
+-- action. For example, to send the window left, press and release
+-- Control+s, and then press h.
+--
+--   h/j/k/l => send window to the left/bottom/top/right half of the screen
+--   i => send window to the upper left quarter of the screen
+--   o => send window to the upper right quarter of the screen
+--   , => send window to the lower left quarter of the screen
+--   . => send window to the lower right quarter of the screen
+--   return => make window full screen
+--   n => send window to the next monitor
+--   left => send window to the monitor on the left (if there is one)
+--   right => send window to the monitor on the right (if there is one)
+--------------------------------------------------------------------------------
+
+return {
+  modifiers = {'ctrl'},
+  trigger   = 's',
+  mappings  = {
+    { {},         'return', 'maximize' },
+    { {},         'space',  'centerWithFullHeight' },
+    { {},         'h',      'left' },
+    { {},         'j',      'down' },
+    { {},         'k',      'up' },
+    { {},         'l',      'right' },
+    { {'shift'},  'h',      'left40' },
+    { {'shift'},  'l',      'right60' },
+    { {},         'i',      'upLeft' },
+    { {},         'o',      'upRight' },
+    { {},         ',',      'downLeft' },
+    { {},         '.',      'downRight' },
+    { {},         'n',      'nextScreen' },
+    { {},         'right',  'moveOneScreenEast' },
+    { {},         'left',   'moveOneScreenWest' },
+  }
+}

--- a/hammerspoon/windows.lua
+++ b/hammerspoon/windows.lua
@@ -226,6 +226,7 @@ if not status then
 end
 
 local modifiers = windowMappings.modifiers
+local showHelp  = windowMappings.showHelp
 local trigger   = windowMappings.trigger
 local mappings  = windowMappings.mappings
 
@@ -241,16 +242,18 @@ function getModifiersStr(modifiers)
 end
 
 local msgStr = getModifiersStr(modifiers)
-msgStr = 'Window Layout Mode (' .. msgStr .. (string.len(msgStr) > 0 and '+' or '') .. trigger .. ')\n'
+msgStr = 'Window Layout Mode (' .. msgStr .. (string.len(msgStr) > 0 and '+' or '') .. trigger .. ')'
 
 for i, mapping in ipairs(mappings) do
   local modifiers, trigger, winFunction = table.unpack(mapping)
   local hotKeyStr = getModifiersStr(modifiers)
 
-  if string.len(hotKeyStr) > 0 then
-    msgStr = msgStr .. (string.format('%10s+%s => %s\n', hotKeyStr, trigger, winFunction))
-  else
-    msgStr = msgStr .. (string.format('%11s => %s\n', trigger, winFunction))
+  if showHelp == true then
+    if string.len(hotKeyStr) > 0 then
+      msgStr = msgStr .. (string.format('\n%10s+%s => %s', hotKeyStr, trigger, winFunction))
+    else
+      msgStr = msgStr .. (string.format('\n%11s => %s', trigger, winFunction))
+    end
   end
 
   windowLayoutMode:bindWithAutomaticExit(modifiers, trigger, function()


### PR DESCRIPTION
Taking a cue from `hyper-apps-defaults.lua`, make `windows.lua` key bindings user customizable. The WindowsLayout Mode's functionality should be the same, with the exception of the "quick help" status message described below. **EDIT:** added a `showHelp` option, defaulting to `false`.

I did this pretty much as an exercise to learn Hammerspoon/lua scripting, so feel free to close/discard this PR, as desired.

## Summary of changes

- Move all the hard-coded bindings from `windows.lua` into `windows-bindings-defaults.lua`
- Update `windows.lua` to look for `windows-bindings.lua`, falling back to `windows-bindings-defaults.lua` and assign `windowLayoutMode:bindWithAutomaticExit()` bindings from those files
- Update `windowLayoutMode.statusMessage` to display a quick help if `showHelp` option is `true`, based on the windows bindings file:
![screen shot 2017-12-09 at 8 42 47 am](https://user-images.githubusercontent.com/6088612/33797460-22a14744-dcbd-11e7-957e-aeeb6e033a70.png)
- Add `hammerspoon/windows-bindings.lua` to `.gitignore`