### PR TITLE
Persist 'muted' status message when microphone is muted

### DIFF
--- a/hammerspoon/microphone.lua
+++ b/hammerspoon/microphone.lua
@@ -9,7 +9,7 @@ local secondClick = false
 displayStatus = function()
   -- Check if the active mic is muted
   if hs.audiodevice.defaultInputDevice():muted() then
-    messageMuting:notify()
+    messageMuting:show()
   else
     messageHot:notify()
   end
@@ -18,8 +18,10 @@ displayStatus()
 
 toggle = function(device)
   if device:muted() then
+    messageMuting:hide()
     device:setMuted(false)
   else
+    messageMuting:show()
     device:setMuted(true)
   end
 end


### PR DESCRIPTION
I often find myself toggling push-to-talk on/off to gain confidence as to which
mode I'm in (PTT vs. PTM), whereas this change will leave the "muted" status
message on screen when in push-to-talk mode.