### PR TITLE
Enhance format consistency

### DIFF
--- a/hammerspoon/control-escape.lua
+++ b/hammerspoon/control-escape.lua
@@ -3,41 +3,41 @@
 --   https://gist.github.com/arbelt/b91e1f38a0880afb316dd5b5732759f1
 --   https://github.com/jasoncodes/dotfiles/blob/ac9f3ac/hammerspoon/control_escape.lua
 
-send_escape = false
-last_mods = {}
+sendEscape = false
+lastMods = {}
 
-control_key_handler = function()
-  send_escape = false
+controlKeyHandler = function()
+  sendEscape = false
 end
 
-control_key_timer = hs.timer.delayed.new(0.15, control_key_handler)
+controlKeyTimer = hs.timer.delayed.new(0.15, controlKeyHandler)
 
-control_handler = function(evt)
-  local new_mods = evt:getFlags()
-  if last_mods["ctrl"] == new_mods["ctrl"] then
+controlHandler = function(evt)
+  local newMods = evt:getFlags()
+  if lastMods["ctrl"] == newMods["ctrl"] then
     return false
   end
-  if not last_mods["ctrl"] then
-    last_mods = new_mods
-    send_escape = true
-    control_key_timer:start()
+  if not lastMods["ctrl"] then
+    lastMods = newMods
+    sendEscape = true
+    controlKeyTimer:start()
   else
-    if send_escape then
+    if sendEscape then
       keyUpDown({}, 'escape')
     end
-    last_mods = new_mods
-    control_key_timer:stop()
+    lastMods = newMods
+    controlKeyTimer:stop()
   end
   return false
 end
 
-control_tap = hs.eventtap.new({hs.eventtap.event.types.flagsChanged}, control_handler)
-control_tap:start()
+controlTap = hs.eventtap.new({hs.eventtap.event.types.flagsChanged}, controlHandler)
+controlTap:start()
 
-other_handler = function(evt)
-  send_escape = false
+otherHandler = function(evt)
+  sendEscape = false
   return false
 end
 
-other_tap = hs.eventtap.new({hs.eventtap.event.types.keyDown}, other_handler)
-other_tap:start()
+otherTap = hs.eventtap.new({hs.eventtap.event.types.keyDown}, otherHandler)
+otherTap:start()

--- a/hammerspoon/microphone.lua
+++ b/hammerspoon/microphone.lua
@@ -45,7 +45,7 @@ optionHandler = function(event)
     controlKeyTimer:start()
 
   -- fn keyUp
-elseif lastMods['fn'] == true and newMods['fn'] == nil then
+  elseif lastMods['fn'] == true and newMods['fn'] == nil then
     if secondClick then
       secondClick = false
     else

--- a/hammerspoon/microphone.lua
+++ b/hammerspoon/microphone.lua
@@ -24,13 +24,13 @@ toggle = function(device)
   end
 end
 
-optionKeyHandler = function()
+fnKeyHandler = function()
   recentlyClicked = false
 end
 
-controlKeyTimer = hs.timer.delayed.new(0.3, optionKeyHandler)
+controlKeyTimer = hs.timer.delayed.new(0.3, fnKeyHandler)
 
-optionHandler = function(event)
+fnHandler = function(event)
   local device = hs.audiodevice.defaultInputDevice()
   local newMods = event:getFlags()
 
@@ -56,5 +56,5 @@ optionHandler = function(event)
   lastMods = newMods
 end
 
-optionKey = hs.eventtap.new({hs.eventtap.event.types.flagsChanged}, optionHandler)
-optionKey:start()
+fnKey = hs.eventtap.new({hs.eventtap.event.types.flagsChanged}, fnHandler)
+fnKey:start()


### PR DESCRIPTION
This branch follows up on a few items from the addition of shush-like functionality. Some of it [brought up in the discussion](https://github.com/jasonrudolph/keyboard/pull/13#discussion_r105287216) and others arising from changes that have happened since.

Following up on https://github.com/jasonrudolph/keyboard/pull/21, `optionHandler` has been renamed to `fnHandler`, and `optionKeyHandler` has been renamed to `fnKeyHandler`. I could see `fnHandler` triggering some hesitation as `fn` is such a common abbreviation for "function".

I saw these items when trying to figure out how to use the audio-input functionality that is present in `microphone.lua`. I think it would be appropriate to add a description to the README and remove the [TODO](https://github.com/jasonrudolph/keyboard#todo) in this branch, but I would prefer some guidance in doing so as I'd like to keep the language/style consistent. 😄 Feel free to defer or add to this branch