### PR TITLE
fix for bug #54 to add support for right 60% with multiple screens

### DIFF
--- a/hammerspoon/windows.lua
+++ b/hammerspoon/windows.lua
@@ -181,7 +181,7 @@ function hs.window.right60(win)
   local screen = win:screen()
   local max = screen:frame()
 
-  f.x = max.w * 0.4
+  f.x = max.x + (max.w * 0.4)
   f.y = max.y
   f.w = max.w * 0.6
   f.h = max.h


### PR DESCRIPTION
Just needed to include the win.x when calculating the x position.  This is similar to how `hs.window.right` works

```lua
function hs.window.right(win)
  -- ...
  f.x = max.x + (max.w / 2)
  -- ...
end
```