### PR TITLE
Point to moved Karabiner instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ This setup is honed and tested with the following dependencies.
 
 2. Enable accessibility to allow Hammerspoon to do its thing [[screenshot]](screenshots/accessibility-permissions-for-hammerspoon.png)
 
-3. On macOS High Sierra or later, you'll be [prompted to allow Karabiner-Elements to load its kernel extension](https://pqrs.org/osx/karabiner/document.html#usage). Follow the prompts to upgrade your life:
+3. On macOS High Sierra or later, you'll be [prompted to allow Karabiner-Elements to load its kernel extension](https://karabiner-elements.pqrs.org/docs/getting-started/installation/#open-karabiner-elements-preferences). Follow the prompts to upgrade your life:
     1. Click "Open System Preferences" [[screenshot]](https://github.com/jasonrudolph/keyboard/blob/v5.0.0/screenshots/karabiner-elements-system-extension-prompt-1.png)
     1. Click "Allow" [[screenshot]](https://github.com/jasonrudolph/keyboard/blob/v5.0.0/screenshots/karabiner-elements-system-extension-prompt-2.png)
 


### PR DESCRIPTION
Based on the [wayback machine](https://web.archive.org/web/20191113102922/https://pqrs.org/osx/karabiner/document.html) I think this is where it should be pointing now.