### PR TITLE
Removes tap homebrew/cask to fix script/setup

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,3 @@
 tap 'homebrew/bundle'
-tap 'homebrew/cask'
 cask 'karabiner-elements'
 cask 'hammerspoon'


### PR DESCRIPTION
Recently I tried to install keyboard and got the following error:

```bash
brian@Brians-MBP .keyboard % script/setup                                                                          
brew bundle can't satisfy your Brewfile's dependencies.
Satisfy missing dependencies with `brew bundle install`.
Using homebrew/bundle
Tapping homebrew/cask
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it for contributing to Homebrew.
Tapping homebrew/cask has failed!
Using karabiner-elements
Using hammerspoon
Homebrew Bundle failed! 1 Brewfile dependency failed to install.
```

I fixed this error simply by remove the `tap 'homebrew/cask'` from the Brewfile